### PR TITLE
Make test use midonet repos and get rid of OpenJDK

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,5 +1,4 @@
 ---
-- src: geerlingguy.java
-- src: abelboldu.midonet-repos
-- src: abelboldu.zookeeper
-- src: abelboldu.cassandra
+- src: 'https://github.com/midonet/ansible-midonet-repo'
+- src: 'https://github.com/midonet/ansible-zookeeper'
+- src: 'https://github.com/midonet/ansible-cassandra'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,28 +3,16 @@
 - hosts: cluster
   remote_user: root
   become: True
-  tasks:
-    - name: Installing repo for Java 8 in Ubuntu
-      apt_repository: repo='ppa:openjdk-r/ppa'
-      when: "ansible_distribution_release == 'trusty'"
 
 - hosts: cluster
   remote_user: root
   become: True
   roles:
-    - role: geerlingguy.java
-      when: "ansible_os_family == 'Debian'"
-      java_packages:
-        - openjdk-8-jdk
-    - role: geerlingguy.java
-      when: "ansible_os_family == 'RedHat'"
-      java_packages:
-        - java-1.8.0-openjdk
-    - role: abelboldu.midonet-repos
-      midonet_version: current
-    - role: abelboldu.zookeeper
+    - role: ansible-midonet-repo
+      midonet_version: 5.2
+    - role: ansible-zookeeper
       zookeeper_hosts: '{{ groups["cluster"] }}'
-    - role: abelboldu.cassandra
+    - role: ansible-cassandra
       cassandra_hosts: '{{ groups["cluster"] }}'
     - role: ansible-midonet-cluster
       zookeeper_hosts: '{{ groups["cluster"] }}'


### PR DESCRIPTION
ansible-midonet-repo, ansible-zookeeper & ansible-cassandra repos were copied
to midonet project. Also, ansible-midonet-repo now takes care of setting up
OpenJDK 8 PPA on trusty now (and the rest of supported distros already provide
it by default).
