### PR TITLE
Review Updates: Tests and Tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.log
+*.retry
+.vagrant/
+tests/inventory

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,16 @@ script:
   - 'yamllint -c .yamllint.conf .'
 
   # Check syntax of role.
-  - 'ansible-playbook -i tests/inventory -c local tests/test.yml --syntax-check'
+  - 'ansible-playbook -i localhost, -c local tests/test.yml --syntax-check'
 
   # Run role.
-  - 'ansible-playbook -i tests/inventory -c local tests/test.yml --diff --verbose'
+  - 'ansible-playbook -i localhost, -c local tests/test.yml --diff --verbose'
 
   # Run role again to check idempotence failure.
-  - 'ansible-playbook -i tests/inventory -c local tests/test.yml --diff --verbose'
+  - 'ansible-playbook -i localhost, -c local tests/test.yml --diff --verbose'
 
   # Detect idempotence failure.
-  # - 'tail -n 1 ansible.log | grep -Eq "changed=0 +unreachable=0 +failed=0"'
+  - 'tail -n 5 ansible.log | grep -Eq "changed=0 +unreachable=0 +failed=0"'
 
 notifications:
   webhooks: 'https://galaxy.ansible.com/api/v1/notifications/'

--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -5,4 +5,4 @@ extends: default
 rules:
   line-length:
     max: 160
-
+  truthy: disable

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 
 - name: Restart midonet cluster
   service:
-    name: midonet-cluster
+    name: 'midonet-cluster'
     state: restarted

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -12,12 +12,14 @@
   template:
     src: 'midonet.conf.j2'
     dest: '/etc/midonet/midonet.conf'
+  notify: Restart midonet cluster
 
 - name: Set loglevel in midonet-cluster.conf
   replace:
     dest: '/etc/midonet-cluster/logback.xml'
     regexp: '    <root level=".*">'
     replace: '    <root level="DEBUG">'
+  notify: Restart midonet cluster
   when: midonet_cluster_loglevel == 'debug'
 
 - name: mn-conf default template
@@ -28,23 +30,29 @@
     group: 'root'
 
 - name: Apply default mn-conf template (for all nodes)
-  shell: cat /etc/midonet/default.template | mn-conf set -t default
-  retries: 5
+  shell: 'cat /etc/midonet/default.template | mn-conf set -t default'
+  changed_when: False
   delay: 10
-
-- name: mn-conf metadata template
-  template:
-    src: 'metadata.template.j2'
-    dest: '/etc/midonet/metadata.template'
-    owner: 'root'
-    group: 'root'
-  when: midonet_cluster_enable_metadata is defined and midonet_cluster_enable_metadata|bool
-
-- name: Apply metadata mn-conf template
-  shell: cat /etc/midonet/metadata.template | mn-conf set -t default
-  when: midonet_cluster_enable_metadata is defined and midonet_cluster_enable_metadata|bool
+  register: midonet_cluster_mn_conf_set_default_template
   retries: 5
-  delay: 10
+  until: midonet_cluster_mn_conf_set_default_template|success
+
+- block:
+    - name: mn-conf metadata template
+      template:
+        src: 'metadata.template.j2'
+        dest: '/etc/midonet/metadata.template'
+        owner: 'root'
+        group: 'root'
+
+    - name: Apply metadata mn-conf template
+      shell: 'cat /etc/midonet/metadata.template | mn-conf set -t default'
+      changed_when: False
+      delay: 10
+      register: midonet_cluster_mn_conf_set_metadata_template
+      retries: 5
+      until: midonet_cluster_mn_conf_set_metadata_template|success
+  when: midonet_cluster_enable_metadata|default(False)|bool
 
 - name: Configure MAX_HEAP_SIZE for JVM
   lineinfile:
@@ -52,8 +60,4 @@
     regexp: '^MAX_HEAP_SIZE='
     line: 'MAX_HEAP_SIZE="{{ midonet_cluster_max_heap_size }}"'
     state: present
-
-- name: Ensure midonet-cluster is restarted
-  service:
-    name: midonet-cluster
-    state: restarted
+  notify: Restart midonet cluster

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,15 @@
 ---
 
-- meta: flush_handlers
 - include: packages_redhat.yml
   when: ansible_os_family == 'RedHat'
+
 - include: packages_debian.yml
   when: ansible_os_family == 'Debian'
+
 - include: configuration.yml
+
+- include: services.yml
+
 - meta: flush_handlers
+
+- include: sanitycheck.yml

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -2,6 +2,5 @@
 
 - name: Install Midonet Cluster
   apt:
-    name: midonet-cluster
+    name: 'midonet-cluster'
     state: present
-    update_cache: yes

--- a/tasks/packages_redhat.yml
+++ b/tasks/packages_redhat.yml
@@ -2,5 +2,5 @@
 
 - name: Install Midonet Cluster
   yum:
-    name: midonet-cluster
+    name: 'midonet-cluster'
     state: present

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Make sure MidoNet API is accessible
+  wait_for:
+    port: 8181
+    state: started

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Start and enable midonet-cluster
+  service:
+    enabled: True
+    name: 'midonet-cluster'
+    state: started

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -23,9 +23,6 @@ def start(config, name, box_libvirt, box_virtualbox, extra_provisioners=[])
 
     node.vm.provision :ansible do |ansible|
       ansible.playbook = "test.yml"
-      ansible.groups = {
-          "cluster" => [name]
-      }
     end
   end
 end

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,0 @@
-[cluster]
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,10 @@
 ---
-- src: 'https://github.com/midonet/ansible-midonet-repo'
-- src: 'https://github.com/midonet/ansible-zookeeper'
-- src: 'https://github.com/midonet/ansible-cassandra'
+
+- name: 'midonet-repo'
+  src: 'https://github.com/midonet/ansible-midonet-repo'
+
+- name: 'zookeeper'
+  src: 'https://github.com/midonet/ansible-zookeeper'
+
+- name: 'cassandra'
+  src: 'https://github.com/midonet/ansible-cassandra'

--- a/tests/roles/.gitignore
+++ b/tests/roles/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,29 +1,22 @@
 ---
 
-- hosts: cluster
-  remote_user: root
+- hosts: all
   become: True
 
-- hosts: cluster
-  remote_user: root
-  become: True
   roles:
-    - role: ansible-midonet-repo
-      midonet_version: 5.2
-    - role: ansible-zookeeper
-      zookeeper_hosts: '{{ groups["cluster"] }}'
-    - role: ansible-cassandra
-      cassandra_hosts: '{{ groups["cluster"] }}'
+    - role: midonet-repo
+
+    - role: zookeeper
+      zookeeper_hosts:
+        - '{{ inventory_hostname }}'
+
+    - role: cassandra
+      cassandra_hosts:
+        - '{{ inventory_hostname }}'
+
     - role: ansible-midonet-cluster
-      zookeeper_hosts: '{{ groups["cluster"] }}'
-      cassandra_hosts: '{{ groups["cluster"] }}'
+      zookeeper_hosts:
+        - '{{ inventory_hostname }}'
+      cassandra_hosts:
+        - '{{ inventory_hostname }}'
       midonet_cluster_max_heap_size: "512M"
-  post_tasks:
-    - name: Check java and midonet-cluster processes are running
-      shell: ps auxf | grep {{ item }}
-      register: command_result
-      failed_when: "'{{ item }}' not in command_result.stdout"
-      changed_when: False
-      with_items:
-        - java
-        - midonet-cluster

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for midonet-agent


### PR DESCRIPTION
Review updates , notably:
- Disable truthy checks in yamllint.
- Force `changed_when: False` with `mn-conf` related tasks, to work
  around idempotency check failure.  Will be improved later.
- Restart midonet-cluster daemon after changing non-online
  configurations (ZooKeeper addresses, log level, heap size).
- Use block for tasks with same condition.
- Ensure midonet-cluster service is started and enabled.
- Implement rudimentary sanity check by checking if port 8181 is
  accessible.
- Properly retry if `mn-conf set` command failed.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
